### PR TITLE
drv: cvitek: remove using macro from source file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bsp/cvitek/cv18xx_risc-v/applications/test"]
+	path = bsp/cvitek/cv18xx_risc-v/applications/test
+	url = git@github.com:unicornx/rtt-duo.git

--- a/bsp/cvitek/cv18xx_risc-v/applications/SConscript
+++ b/bsp/cvitek/cv18xx_risc-v/applications/SConscript
@@ -1,7 +1,7 @@
 from building import *
 
 cwd     = GetCurrentDir()
-src     = Glob('*.c') + Glob('*.cpp')
+src     = Glob('*.c') + Glob('*.cpp') + Glob('test/*.c')
 CPPPATH = [cwd]
 
 group = DefineGroup('Applications', src, depend = [''], CPPPATH = CPPPATH)

--- a/bsp/cvitek/cv18xx_risc-v/mkcard.sh
+++ b/bsp/cvitek/cv18xx_risc-v/mkcard.sh
@@ -13,6 +13,11 @@ if [[ -z "${UDISK}" ]]; then
 	UDISK=/home/u/ws/u-disk
 fi
 
+if [[ -z "${BOARD}" ]]; then
+        BOARD=duo256m
+fi
+
+
 ROOT=`pwd`
 
 sudo umount $UDISK
@@ -27,7 +32,7 @@ sudo rm $UDISK/boot.sd
 echo "Removing Done!"
 
 echo "Copying to sd-card ......"
-sudo cp $ROOT/../output/milkv-duo/boot.sd $UDISK
+sudo cp $ROOT/../output/milkv-$BOARD/boot.sd $UDISK
 echo "Copying Done!"
 
 sudo umount $UDISK

--- a/bsp/cvitek/cv18xx_risc-v/mkcard.sh
+++ b/bsp/cvitek/cv18xx_risc-v/mkcard.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script is used to flash the sd-card.
+# Customize DEV/UDISK with your environment.
+# @DEV: device name of your sdcard
+# @UDISK: mount point of your sdcard
+
+if [[ -z "${DEV}" ]]; then
+	DEV=/dev/sdb1
+fi
+
+if [[ -z "${UDISK}" ]]; then
+	UDISK=/home/u/ws/u-disk
+fi
+
+ROOT=`pwd`
+
+sudo umount $UDISK
+sudo mount $DEV $UDISK
+if [ 0 -ne $? ]; then
+	echo "Mount failed, please check and retry!"
+	exit -1
+fi
+
+echo "Removing ......"
+sudo rm $UDISK/boot.sd
+echo "Removing Done!"
+
+echo "Copying to sd-card ......"
+sudo cp $ROOT/../output/milkv-duo/boot.sd $UDISK
+echo "Copying Done!"
+
+sudo umount $UDISK
+
+echo "Done!"
+


### PR DESCRIPTION
修改原因具体参考 commit mesage.

有个疑问，还有一个 `bsp/cvitek/drivers/drv_gpio.c` 文件我还没有改动，原因是我发现目前 Kconfig 中还没有 `RT_USING_PIN` 的配置项。

还有一个疑问是我发现在 `bsp/cvitek/drivers/SConscript` 中 
```
if GetDepend('BSP_USING_CV18XX'):
    src += ['drv_gpio.c']
```

所以我想先确认一下对于 GPIO 这个，原先的设计是怎么考虑的，我们是否可以直接将其和 UART 一样对待，即默认加入 `drv_gpio.c`，参考 `bsp/allwinner/libraries/drivers/SConscript`, 默认加入了  'drv_uart.c' 和 'drv_pin.c'