### PR TITLE
drv: cvitek: remove using macro from source file

### DIFF
--- a/bsp/cvitek/drivers/drv_adc.c
+++ b/bsp/cvitek/drivers/drv_adc.c
@@ -11,8 +11,6 @@
 #include <rtdevice.h>
 #include "drv_adc.h"
 
-#ifdef BSP_USING_ADC
-
 #define DBG_LEVEL   DBG_LOG
 #include <rtdbg.h>
 #define LOG_TAG "DRV.ADC"
@@ -117,5 +115,3 @@ int rt_hw_adc_init(void)
     return RT_EOK;
 }
 INIT_BOARD_EXPORT(rt_hw_adc_init);
-
-#endif /* BSP_USING_ADC */

--- a/bsp/cvitek/drivers/drv_pwm.c
+++ b/bsp/cvitek/drivers/drv_pwm.c
@@ -11,8 +11,6 @@
 #include <rtdevice.h>
 #include "drv_pwm.h"
 
-#ifdef BSP_USING_PWM
-
 #define DBG_LEVEL   DBG_LOG
 #include <rtdbg.h>
 #define LOG_TAG "DRV.PWM"
@@ -208,5 +206,3 @@ int rt_hw_pwm_init(void)
 #endif
 }
 INIT_BOARD_EXPORT(rt_hw_pwm_init);
-
-#endif /* BSP_USING_PWM */

--- a/bsp/cvitek/drivers/drv_rtc.c
+++ b/bsp/cvitek/drivers/drv_rtc.c
@@ -11,8 +11,6 @@
 #include <rtthread.h>
 #include <rtdevice.h>
 
-#ifdef BSP_USING_RTC
-
 #define DBG_TAG "DRV.RTC"
 #define DBG_LVL DBG_WARNING
 #include <rtdbg.h>
@@ -405,5 +403,3 @@ static int rt_hw_rtc_init(void)
     return RT_EOK;
 }
 INIT_DEVICE_EXPORT(rt_hw_rtc_init);
-
-#endif /* BSP_USING_RTC */

--- a/bsp/cvitek/drivers/drv_spi.c
+++ b/bsp/cvitek/drivers/drv_spi.c
@@ -9,7 +9,6 @@
  */
 
 #include "drv_spi.h"
-#ifdef RT_USING_SPI
 
 #define DBG_TAG "drv.spi"
 #define DBG_LVL DBG_INFO
@@ -231,5 +230,3 @@ int rt_hw_spi_init(void)
     return ret;
 }
 INIT_BOARD_EXPORT(rt_hw_spi_init);
-
-#endif /* RT_USING_SPI */

--- a/bsp/cvitek/drivers/drv_wdt.c
+++ b/bsp/cvitek/drivers/drv_wdt.c
@@ -11,8 +11,6 @@
 #include <rtdevice.h>
 #include "drv_wdt.h"
 
-#ifdef BSP_USING_WDT
-
 #define DBG_LEVEL   DBG_LOG
 #include <rtdbg.h>
 #define LOG_TAG "DRV.WDT"
@@ -161,5 +159,3 @@ int rt_hw_wdt_init(void)
     return RT_EOK;
 }
 INIT_BOARD_EXPORT(rt_hw_wdt_init);
-
-#endif /* BSP_USING_WDT */


### PR DESCRIPTION
修改原因具体参考 commit mesage.

有个疑问，还有一个 `bsp/cvitek/drivers/drv_gpio.c` 文件我还没有改动，原因是我发现目前 Kconfig 中还没有 `RT_USING_PIN` 的配置项。

还有一个疑问是我发现在 `bsp/cvitek/drivers/SConscript` 中 
```
if GetDepend('BSP_USING_CV18XX'):
    src += ['drv_gpio.c']
```

所以我想先确认一下对于 GPIO 这个，原先的设计是怎么考虑的，我们是否可以直接将其和 UART 一样对待，即默认加入 `drv_gpio.c`，参考 `bsp/allwinner/libraries/drivers/SConscript`, 默认加入了  'drv_uart.c' 和 'drv_pin.c'