### PR TITLE
bsp:cvitek: add calibration for adc

### DIFF
--- a/bsp/cvitek/drivers/drv_adc.c
+++ b/bsp/cvitek/drivers/drv_adc.c
@@ -103,7 +103,13 @@ static const struct rt_adc_ops _adc_ops =
 int rt_hw_adc_init(void)
 {
     rt_uint8_t i;
-    for (i = 0; i < sizeof(adc_dev_config) / sizeof(adc_dev_config[0]); i ++)
+
+    for (i = 0; i < sizeof(adc_dev_config) / sizeof(adc_dev_config[0]); i++)
+    {
+        cvi_do_calibration(adc_dev_config[i].base);
+    }
+
+    for (i = 0; i < sizeof(adc_dev_config) / sizeof(adc_dev_config[0]); i++)
     {
         if (rt_hw_adc_register(&adc_dev_config[i].device, adc_dev_config[i].name, &_adc_ops, &adc_dev_config[i]) != RT_EOK)
         {

--- a/bsp/cvitek/drivers/drv_adc.h
+++ b/bsp/cvitek/drivers/drv_adc.h
@@ -48,6 +48,11 @@
 #define SARADC_RESULT_MASK                  0x0FFF
 #define SARADC_RESULT_VALID                 (1 << 15)
 
+#define SARADC_TEST_OFFSET                  0x030
+#define SARADC_TEST_VREFSEL_BIT             2
+
+#define SARADC_TRIM_OFFSET                  0x034
+
 rt_inline void cvi_set_saradc_ctrl(unsigned long reg_base, rt_uint32_t value)
 {
     value |= mmio_read_32(reg_base + SARADC_CTRL_OFFSET);
@@ -76,6 +81,19 @@ rt_inline void cvi_set_cyc(unsigned long reg_base)
 
     value |= SARADC_CYC_CLKDIV_DIV_16;                                                               //set saradc clock cycle=840ns
     mmio_write_32(reg_base + SARADC_CYC_SET_OFFSET, value);
+}
+
+rt_inline void cvi_do_calibration(unsigned long reg_base)
+{
+    rt_uint32_t val;
+
+    val = mmio_read_32(reg_base + SARADC_TEST_OFFSET);
+    val |= 1 << SARADC_TEST_VREFSEL_BIT;
+    mmio_write_32(reg_base + SARADC_TEST_OFFSET, val);
+
+    val = mmio_read_32(reg_base + SARADC_TRIM_OFFSET);
+    val |= 0x4;
+    mmio_write_32(reg_base + SARADC_TRIM_OFFSET, val);
 }
 
 int rt_hw_adc_init(void);


### PR DESCRIPTION
需要在初始化阶段对 adc 控制器进行校准，否则测量的电压值不准确。