### PR TITLE
bsp: cvitek: remove warning when building wdt driver

### DIFF
--- a/bsp/cvitek/drivers/drv_wdt.c
+++ b/bsp/cvitek/drivers/drv_wdt.c
@@ -23,6 +23,7 @@ struct _cvi_wdt_dev
     struct rt_watchdog_device device;
     const char *name;
     rt_uint32_t base;
+    rt_uint32_t timeout;
 };
 
 static struct _cvi_wdt_dev _wdt_dev[] =
@@ -113,11 +114,11 @@ static rt_err_t _wdt_control(rt_watchdog_t *wdt_device, int cmd, void *arg)
         cvi_wdt_feed_en(reg_base);
         break;
     case RT_DEVICE_CTRL_WDT_SET_TIMEOUT:
-        csi_wdt_set_timeout(reg_base, *(rt_uint32_t *)arg);
-        wdt_device->parent.user_data = (rt_uint32_t)(*(rt_uint32_t *)arg);
+        wdt->timeout = *(rt_uint32_t *)arg;
+        csi_wdt_set_timeout(reg_base, wdt->timeout);
         break;
     case RT_DEVICE_CTRL_WDT_GET_TIMEOUT:
-        *(rt_uint32_t *)arg = (rt_uint32_t)wdt_device->parent.user_data;
+        *(rt_uint32_t *)arg = wdt->timeout;
         break;
     case RT_DEVICE_CTRL_WDT_GET_TIMELEFT:
         *(rt_uint32_t *)arg = (cvi_wdt_get_counter_value(reg_base) / (WDT_FREQ_DEFAULT / 1000U));


### PR DESCRIPTION
```
./bsp/cvitek/drivers/drv_wdt.c: In function '_wdt_control':
warning: assignment to 'void *' from 'unsigned int' makes pointer
from integer without a cast [-Wint-conversion]
  119 |         wdt_device->parent.user_data = (rt_uint32_t)(*(rt_uint32_t *)arg);
      |                                      ^
warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  122 |         *(rt_uint32_t *)arg = (rt_uint32_t)wdt_device->parent.user_data;
      |                               ^
```

Rootcasue: It's not portable to store integar in a pointer.

Solution: use global _wdt_dev to store the timeout value.

