### PR TITLE
bsp: cvitek: remove cvitek_bootloader from git ignore file

### DIFF
--- a/bsp/cvitek/.gitignore
+++ b/bsp/cvitek/.gitignore
@@ -1,4 +1,3 @@
-cvitek_bootloader
 fip.bin
 boot.sd
 output


### PR DESCRIPTION
cvitek_bootloader will not be downloaded and no need to ignore this for git.

Fixes: 2ce9d9471880 ("[bsp/cvitek] Update packaging method")

